### PR TITLE
タップするとアプリが落ちる

### DIFF
--- a/android/src/main/java/io/github/karino2/paoogo/ui/vs_engine/PlayAgainstEngineActivity.kt
+++ b/android/src/main/java/io/github/karino2/paoogo/ui/vs_engine/PlayAgainstEngineActivity.kt
@@ -68,6 +68,8 @@ class PlayAgainstEngineActivity : GoActivity() {
     private var syncing = false;
 
     override fun doTouch(event: MotionEvent) {
+        if (!::engine.isInitialized)
+            return
         if (engineGoGame.engineNowBlack() or engineGoGame.engineNowWhite()) {
             showInfoToast(R.string.not_your_turn)
         } else {


### PR DESCRIPTION
* 対局中に「碁盤の下の横線」の下の空白部分をタップした場合
* AI初期化中に碁盤をタップした場合
