### PR TITLE
最後の着手が表示されない

### DIFF
--- a/android/src/main/java/io/github/karino2/paoogo/ui/vs_engine/PlayAgainstEngineActivity.kt
+++ b/android/src/main/java/io/github/karino2/paoogo/ui/vs_engine/PlayAgainstEngineActivity.kt
@@ -151,9 +151,17 @@ class PlayAgainstEngineActivity : GoActivity() {
     private fun genMove() {
         engineGoGame.aiIsThinking = true
         game.clearHint()
+        android.view.Choreographer.getInstance().postFrameCallback {
+            runGenMove()
+        }
+    }
+
+    private fun runGenMove() {
         val waiter = Waiter(200)
         lifecycleScope.launch {
-            val move = engine.genMove(game.isBlackToMove)
+            val move = withContext(kotlinx.coroutines.Dispatchers.Default) {
+                engine.genMove(game.isBlackToMove)
+            }
             waiter.mayWait()
             withContext(Dispatchers.Main) {
                 if (move.pass) {


### PR DESCRIPTION
AI との対局で, 人間側が打った石がちゃんと表示されないまま AI の思考時間に入ってしまうことがときどきありました. 石が表示されなかったり, 薄い石が表示されたりです. humanSL で思考時間が長くなると目立ちます.

以下をすれば, 思考中も「最後の着手がちゃんと丸印つきで表示」されました.

* フレーム描画のタイミングを待ってから genmove
* genmove をワーカースレッドに

なお, 別 PR のスピナー表示を採用いただける場合は, 同じコミットがあちらにも含まれるので, こちらの PR は不要です.