### PR TITLE
KataGo 通常モデルと人間モデルの併用 (kotlin 側)

### DIFF
--- a/android/src/main/java/io/github/karino2/paoogo/goengine/EngineRepository.kt
+++ b/android/src/main/java/io/github/karino2/paoogo/goengine/EngineRepository.kt
@@ -49,10 +49,11 @@ class EngineRepository(val context: Context, val assetManager: AssetManager) {
         val setup = KataGoSetup(context, assetManager)
         setup.extractFiles()
         KataGoNative().apply {
-            initNative(
+            initNativeHum(
                 Runtime.getRuntime().availableProcessors(),
                 setup.configFile.absolutePath,
-                setup.modelFile.absolutePath
+                setup.modelFile.absolutePath,
+                setup.humanModelFile?.absolutePath ?: "",
             )
         }
     }

--- a/android/src/main/java/io/github/karino2/paoogo/goengine/katago/KataGoNative.kt
+++ b/android/src/main/java/io/github/karino2/paoogo/goengine/katago/KataGoNative.kt
@@ -14,10 +14,12 @@ class KataGoNative : GoEngine, GoAnalyzer {
         }
 
     }
+    external fun initNativeHum(threadNum: Int, cfgPath: String, modelPath: String, humanModelPath: String)
     external fun initNative(threadNum: Int, cfgPath: String, modelPath: String)
     override external fun setKomi(komi: Float)
     override external fun clearBoard()
     override external fun setBoardSize(size: Int)
+    external fun setGenmoveProfile(profile: String)
     override external fun doMove(x: Int, y: Int, isBlack: Boolean) : Boolean
     override external fun genMoveInternal(isBlack: Boolean) : Int
     override fun debugInfo(): String? {

--- a/android/src/main/java/io/github/karino2/paoogo/goengine/katago/KataGoSetup.kt
+++ b/android/src/main/java/io/github/karino2/paoogo/goengine/katago/KataGoSetup.kt
@@ -7,7 +7,11 @@ import java.io.File
 class KataGoSetup(val context: Context, val assetManager: AssetManager) {
     companion object {
         val MODEL_NAME="kata1-b6c96-s175395328-d26788732.txt.gz"
+        val HUMAN_MODEL_NAME=null
         val CFG_NAME="gtp_jp.cfg"
+        // val MODEL_NAME="g170e-b10c128-s1141046784-d204142634.bin.gz"
+        // val HUMAN_MODEL_NAME="b18c384nbt-humanv0.bin.gz"
+        // val CFG_NAME="gtp_human.cfg"
     }
 
     fun ensureDir(relative: String) {
@@ -23,7 +27,7 @@ class KataGoSetup(val context: Context, val assetManager: AssetManager) {
         // txt.gz is automatically modified to txt.
         // noCompress is not working for txt.gz.
         // https://stackoverflow.com/questions/4666098/why-does-android-aapt-remove-gz-file-extension-of-assets
-        val assetName = fname.replace("txt.gz", "txt_gz")
+        val assetName = fname.replace("txt.gz", "txt_gz").replace("bin.gz", "bin_gz")
         val dest = getFile("katago/${fname}")
         if (dest.exists())
             return
@@ -44,6 +48,7 @@ class KataGoSetup(val context: Context, val assetManager: AssetManager) {
 
     fun extractFiles() {
         ensureFileCopy(MODEL_NAME)
+        HUMAN_MODEL_NAME?.let { ensureFileCopy(it) }
         // update config often for a while.
         ensureDelete(CFG_NAME)
         ensureFileCopy(CFG_NAME)
@@ -54,5 +59,8 @@ class KataGoSetup(val context: Context, val assetManager: AssetManager) {
 
     val modelFile: File
         get() = getFile("katago/${MODEL_NAME}")
+
+    val humanModelFile: File?
+        get() = HUMAN_MODEL_NAME?.let { getFile("katago/$it") }
 
 }


### PR DESCRIPTION
(https://github.com/karino2/KataGo/pull/4 を前提としています)

HUMAN_MODEL_NAME を指定して, KataGo の通常モデルと人間モデルの併用ができるようにするパッチです. メリットは上記の katago 側 PR を参照ください.

もし本家に取り込んでもらえたら, 私版との差分は, ほとんど自明な設定や UI の直しだけになります.