### PR TITLE
エンジンレベル数を減らすと起動時にクラッシュ

### DIFF
--- a/android/src/main/java/io/github/karino2/paoogo/ui/GameStartActivity.kt
+++ b/android/src/main/java/io/github/karino2/paoogo/ui/GameStartActivity.kt
@@ -61,6 +61,7 @@ class GameStartActivity : AppCompatActivity() {
         levelSpinner.adapter = levelAdapter
 
         with(GoPrefs) {
+            engineLevel = engineLevel.coerceIn(1, levelAdapter.count)
             if(lastBoardSize == 13) findViewById<RadioButton>(R.id.board_size_13).isChecked = true
             if(engineLevel != 1) levelSpinner.setSelection(engineLevel - 1)
         }

--- a/android/src/main/res/layout/activity_game_start.xml
+++ b/android/src/main/res/layout/activity_game_start.xml
@@ -46,6 +46,7 @@
     <Spinner
         android:id="@+id/level_spinner"
         android:layout_below="@id/level_label"
+        android:saveEnabled="false"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
     </Spinner>


### PR DESCRIPTION
私版で katago と対局したあと本家をインストールしなおすと, 起動時に落ちます. ユーザ側で直すには, 「アプリ情報 → ストレージ → データを削除」が必要です.

私版のほうで ID (`level_spinner`) などを変えればいいのでしょうけれど, どうせなら予防策を入れておきませんか. 今後もし何かでエンジンレベル数を減らしたときに, 上記をユーザに案内するのはめんどうなので.