### PR TITLE
KataGo の新しめのモデルへの対応

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -92,7 +92,7 @@ android {
         warning 'MissingTranslation', 'ResourceType', 'InvalidPackage'
     }
     androidResources {
-        noCompress 'bin', 'txt_gz'
+        noCompress 'bin', 'txt_gz', 'bin_gz'
     }
 } // android
 


### PR DESCRIPTION
これも足していただけないでしょうか. ある時期以降はモデルの拡張子は `bin.gz` です. (KataGoSetup.kt は対応済)