### PR TITLE
夜間モードの切りかわりでタイトル画面に戻る

### DIFF
--- a/android/src/main/java/org/ligi/gobandroid_hd/ui/GoPrefs.kt
+++ b/android/src/main/java/org/ligi/gobandroid_hd/ui/GoPrefs.kt
@@ -67,7 +67,7 @@ object GoPrefs : KotprefModel() {
     var isTransitionDone: Boolean by booleanPref(default = false)
     var isTsumegoCleanDone: Boolean by booleanPref(default = false)
 
-    private val dayNightModeString: String by stringPref(key = R.string.prefs_daynight)
+    private val dayNightModeString: String by stringPref(key = R.string.prefs_daynight, default="day")
     private var lastSeenSGFPackInt: Int by intPref()
 
     @AppCompatDelegate.NightMode


### PR DESCRIPTION
AI の考慮中に 22:00 (碁盤の色が変わるタイミング) になるとタイトル画面に戻ります. とりあえず安直に夜間モードを止めるパッチ.

#13 を revert しても発症. さらに #12 #11 を revert すると発症せず.